### PR TITLE
Add newline to action binding messages

### DIFF
--- a/hrdevhelper.py
+++ b/hrdevhelper.py
@@ -28,7 +28,7 @@ class HRDevHelper(ida_idaapi.plugin_t):
 
     def _register_action(self, hotkey, desc):
         actname = HRDevHelper.get_action_name(desc)
-        ida_kernwin.msg("%s -> %s" % (hotkey, actname))
+        ida_kernwin.msg("%s -> %s\n" % (hotkey, actname))
         if ida_kernwin.register_action(ida_kernwin.action_desc_t(
             actname,
             desc,


### PR DESCRIPTION
This prevents them all from being printed on the same line (confusingly).