### PR TITLE
Fix graph not showing first time, add obj_ea to var and obj op types

### DIFF
--- a/hrdh/graph.py
+++ b/hrdh/graph.py
@@ -109,7 +109,6 @@ class cfunc_graph_t(ida_graph.GraphViewer):
                 ida_kernwin.get_widget_title(target),
                 self.dock_position)
             self.Refresh()
-        ida_graph.viewer_fit_window(widget)
 
     def update(self, cfunc=None, objs=None, focus=None):
         if cfunc:
@@ -167,7 +166,9 @@ class cfunc_graph_t(ida_graph.GraphViewer):
                 ida_hexrays.cot_var]:
             name = self._get_expr_name(expr)
             parts.append("%s.%d %s" % (type_name, expr.refwidth, name))
-            parts.append("obj_ea: %x" % item.obj_ea)
+
+            if op == ida_hexrays.cot_obj:
+                parts.append("obj_ea: %x" % item.obj_ea)
         elif op in [
                 ida_hexrays.cot_num,
                 ida_hexrays.cot_helper,

--- a/hrdh/graph.py
+++ b/hrdh/graph.py
@@ -109,6 +109,7 @@ class cfunc_graph_t(ida_graph.GraphViewer):
                 ida_kernwin.get_widget_title(target),
                 self.dock_position)
             self.Refresh()
+        ida_graph.viewer_fit_window(widget)
 
     def update(self, cfunc=None, objs=None, focus=None):
         if cfunc:
@@ -166,6 +167,7 @@ class cfunc_graph_t(ida_graph.GraphViewer):
                 ida_hexrays.cot_var]:
             name = self._get_expr_name(expr)
             parts.append("%s.%d %s" % (type_name, expr.refwidth, name))
+            parts.append("obj_ea: %x" % item.obj_ea)
         elif op in [
                 ida_hexrays.cot_num,
                 ida_hexrays.cot_helper,


### PR DESCRIPTION
Thanks for your awesome plugin!


Here is a patch that fixes the graph sometimes not being visible when it first shows up. This can be fixed manually by clicking 'fit window' in the graph view, I do that programmatically here. I've also added output to show the obj_ea to var and obj types as this is sometimes useful to know during dev.